### PR TITLE
Fix Atom auto-discovery (Most obnoxious PR ever, probably)

### DIFF
--- a/_includes/themes/tom/default.html
+++ b/_includes/themes/tom/default.html
@@ -4,7 +4,7 @@
         <meta http-equiv="content-type" content="text/html; charset=utf-8" />
         <title>{{ page.title }}</title>
         <meta name="author" content="{{ site.author.name }}" />
-        <link href="http://feeds.feedburner.com/{{ site.author.feedburner }}" rel="alternate" title="your title" type="application/atom+xml" />
+        <link href="http://swannodette.github.com/atom.xml" rel="alternate" title="dosync" type="application/atom+xml" />
 
         <!-- syntax highlighting CSS -->
         <link rel="stylesheet" href="{{ ASSET_PATH }}/css/syntax.css" type="text/css" />


### PR DESCRIPTION
Yo - I went to subscribe to your atom feed today just by copying and pasting http://swannodette.github.com/ into my reader and it failed.  I know you have an RSS link on your site, but figured I'd patch up auto-discovery for ya.
