### PR TITLE
fan-in: fix nil put on out channel, deadlock

### DIFF
--- a/code/blog/src/blog/utils/reactive.cljs
+++ b/code/blog/src/blog/utils/reactive.cljs
@@ -115,11 +115,17 @@
             (close! out))))
     out))
 
-(defn fan-in [ins]
-  (let [out (chan)]
-    (go (while true
-          (let [[x] (alts! ins)]
-            (>! out x))))
+(defn fan-in
+  ([ins] (fan-in ins (chan)))
+  ([ins out]
+    (go (loop [ins (vec ins)]
+          (when (> (count ins) 0)
+            (let [[x in] (alts! ins)]
+              (when x
+                (>! out x)
+                (recur ins))
+              (recur (vec (disj (set ins) in))))))
+        (close! out))
     out))
 
 (defn take-until


### PR DESCRIPTION
You don't run into this for the autocomplete example, but there is a potential error in fan-in.
I noticed it because I ran into the same problem on another project trying to join multiple channels to one output.
...may or may not be useful.
