### PR TITLE
Fix to stop page-scroll when using arrow keys on menus

### DIFF
--- a/code/blog/src/blog/responsive/core.cljs
+++ b/code/blog/src/blog/responsive/core.cljs
@@ -105,11 +105,11 @@
 (defn key-events [prevent-default?]
   (let [preventer-fn #(when @prevent-default?
                         (.preventDefault %)
-                        (.stopPropagation %))])
-  (->> (r/listen js/document :keydown preventer-fn)
-    (r/map key-event->keycode)
-    (r/filter KEYS)
-    (r/map key->keyword)))
+                        (.stopPropagation %))]
+    (->> (r/listen js/document :keydown preventer-fn)
+      (r/map key-event->keycode)
+      (r/filter KEYS)
+      (r/map key->keyword))))
 
 (defn create-example [id event-fn render-fn ctor-fn]
   (let [hc      (r/hover (dom/by-id id))

--- a/code/blog/src/blog/responsive/core.cljs
+++ b/code/blog/src/blog/responsive/core.cljs
@@ -103,7 +103,10 @@
 ;; Example constructor
 
 (defn key-events [prevent-default?]
-  (->> (r/listen js/document :keydown prevent-default?)
+  (let [preventer-fn #(when @prevent-default?
+                        (.preventDefault %)
+                        (.stopPropagation %))])
+  (->> (r/listen js/document :keydown preventer-fn)
     (r/map key-event->keycode)
     (r/filter KEYS)
     (r/map key->keyword)))
@@ -111,7 +114,7 @@
 (defn create-example [id event-fn render-fn ctor-fn]
   (let [hc      (r/hover (dom/by-id id))
         prevent (atom false)
-        raw     (event-fn #(deref prevent))
+        raw     (event-fn prevent)
         c       (r/toggle raw)
         changes (ctor-fn (:chan c))
         ctrl    (:control c)]


### PR DESCRIPTION
Triggering stop propagation in practice.responsive.core/key-events