### PR TITLE
Make console logs consistent and remove </input>

### DIFF
--- a/_posts/2013-11-07-clojurescript-101.md
+++ b/_posts/2013-11-07-clojurescript-101.md
@@ -58,7 +58,7 @@ First off we want to add the following markup to `index.html` before
 the first script tag which loads `goog/base.js`:
 
 ```
-<input id="query" type="text"></input>
+<input id="query" type="text">
 <button id="search">Search</button>
 <p id="results"></p>
 ```
@@ -82,7 +82,7 @@ We want to confirm that this will work so let's change the
 `console.log` expression so it looks this instead:
 
 ```
-(. js/console (log (dom/getElement "query")))
+(.log js/console (dom/getElement "query"))
 ```
 
 Save the file and it should be recompiled instantly. We should be able


### PR DESCRIPTION
The Input Element has a self-closing tag.
I tried using the initial log syntax for console logs within go blocks and got a compiler warning:
```
WARNING: Use of undeclared Var async-tut1.core/log at line 50 src/async_tut1/core.cljs
```
So I think it's best to consistently use (.log js/console ...) since it works in all contexts.