### PR TITLE
Build with new primitives (remove, always).

### DIFF
--- a/code/blog/src/blog/utils/reactive.cljs
+++ b/code/blog/src/blog/utils/reactive.cljs
@@ -65,13 +65,7 @@
     out))
 
 (defn remove [f in]
-  (let [out (chan)]
-    (go (loop []
-          (if-let [v (<! in)]
-            (do (when-not (f v) (>! out v))
-              (recur))
-            (close! out))))
-    out))
+  (filter (complement f) in))
 
 (defn spool [xs]
   (let [out (chan)]
@@ -150,13 +144,7 @@
             coll)))))
 
 (defn always [v c]
-  (let [out (chan)]
-    (go (loop []
-          (if-let [e (<! c)]
-            (do (>! out v)
-              (recur))
-            (close! out))))
-    out))
+  (map (constantly v) c))
 
 (defn toggle [in]
   (let [out (chan)


### PR DESCRIPTION
Building using previously created entities not only reduces duplication of potential bugs, but reincorporation helps comprehension and concise expression.

This change could go further and even express log as a map over (fn [x] (.log js/console x) x)
