### PR TITLE
Make .site container more fluid. Change link style on smaller screens

### DIFF
--- a/assets/themes/tom/css/screen.css
+++ b/assets/themes/tom/css/screen.css
@@ -19,6 +19,9 @@
 /* Global Reset */
 
 * {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
     margin: 0;
     padding: 0;
 }
@@ -106,7 +109,9 @@ ul.posts span {
 .site {
     font-size: 110%;
     text-align: justify;
-    width: 586px;
+    min-width: 320px;
+    width: 100%;
+    max-width: 586px;
     margin: 3em auto 2em auto;
     line-height: 1.5em;
 }
@@ -136,6 +141,19 @@ ul.posts span {
 
 .site .title a.extra:hover {
     color: black;
+}
+
+@media screen and (max-width: 568px) {
+  .site {
+    padding: 20px;
+  }
+  .site .title a,
+  .site .title a.extra {
+    display: inline-block;
+    margin: 0 auto;
+    width: 100%;
+    text-align: center;
+  }
 }
 
 .site .meta {


### PR DESCRIPTION
Just has some issues with viewing [cljs 101](http://swannodette.github.io/2013/11/07/clojurescript-101/) side-by-side with text editor, hope, you consider this reasonable. Right now it does add like 20px padding for width below 568px, so change 569->568 is accompanied by instant position change for content.