### PR TITLE
use an available version of Om on the blog code

### DIFF
--- a/code/blog/project.clj
+++ b/code/blog/project.clj
@@ -12,7 +12,7 @@
                  [org.clojure/clojurescript "0.0-2173"]
                  [org.clojure/core.async "0.1.267.0-0d7780-alpha"]
                  [org.clojure/core.match "0.2.0"]
-                 [om "0.5.2-SNAPSHOT"]]
+                 [om "0.5.2"]]
 
   :plugins [[lein-cljsbuild "1.0.2"]]
 


### PR DESCRIPTION
Hi, I did cloned your great stuff here and was having problems to get the dependencies because Om 0.5.2-SNAPSHOT is not available on Clojars, but 0.5.2 is.