### PR TITLE
Atom feed error: replace & with &amp;

### DIFF
--- a/_posts/2014-07-26-transit--clojurescript.md
+++ b/_posts/2014-07-26-transit--clojurescript.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Transit, JSON & ClojureScript"
+title: "Transit, JSON &amp; ClojureScript"
 description: ""
 category: 
 tags: []


### PR DESCRIPTION
Hi,

I was trying to subscribe to your feed and found the same error as mentioned in #23
One of your posts' title had a "&" character, I just replaced that with `&amp;` and it
seemed to work.

Not sure if this is better as compared to wrapping the content in a CDATA section.

P.S Thanks for creating om
