### PR TITLE
delete "be" from redundant "be become"

### DIFF
--- a/_posts/2014-12-22-waitin.md
+++ b/_posts/2014-12-22-waitin.md
@@ -16,7 +16,7 @@ Folks who rely primarily on Leiningen however are less likely to have
 experienced the pleasant hardware transition of the past few years. No
 matter how you look at it Leiningen out of the box adds a considerable
 amount of overhead that cannot be blamed on Clojure itself. For
-ClojureScript this overhead can be become somewhat unbearable due to
+ClojureScript this overhead can become somewhat unbearable due to
 the level of indirection. The following identifies three fairly
 straightforward steps to improving ClojureScript cold start compile
 times.


### PR DESCRIPTION
alternative: delete "become" instead