### PR TITLE
Fix links no longer working with trailing slashes in Jekyll3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # This is the default format. 
 # For more see: https://github.com/mojombo/jekyll/wiki/Permalinks
-permalink: /:categories/:year/:month/:day/:title 
+permalink: /:categories/:year/:month/:day/:title/
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
 rouge: true


### PR DESCRIPTION
I ran into this issue recently with my own blog. Existing links with trailing slashes no longer work. For example I was trying to access http://swannodette.github.io/2013/08/31/asynchronous-error-handling/ from several other blogs and received the page does not exist message.

For reference https://github.com/jekyll/jekyll/issues/4440